### PR TITLE
[SOCIALBOT]: American workers are stuck in place because everyone is too afraid of a recession to quit

### DIFF
--- a/src/links/american-workers-are-stuck-in-place-because-everyone-is-too-afraid-of-a-recession-to-quit.md
+++ b/src/links/american-workers-are-stuck-in-place-because-everyone-is-too-afraid-of-a-recession-to-quit.md
@@ -1,0 +1,10 @@
+---
+title: 'American workers are stuck in place because everyone is too afraid of a recession to quit'
+url: https://boredbat.com/american-workers-are-stuck-in-place-because-everyone-is-too-afraid-of-a-recession-to-quit/#google_vignette
+date: 2024-08-18
+thumbnail: https://boredbat.com/wp-content/uploads/2024/08/image-12.jpeg
+tags:
+  - links
+---
+
+The American job market is frozen in fear of a potential recession, with workers stuck in unsatisfying roles and hesitant to quit, despite plummeting job satisfaction and stagnant hiring - a phenomenon eerily mirrored in plummeting Google searches for "quitting job".


### PR DESCRIPTION
The American job market is frozen in fear of a potential recession, with workers stuck in unsatisfying roles and hesitant to quit, despite plummeting job satisfaction and stagnant hiring - a phenomenon eerily mirrored in plummeting Google searches for "quitting job".

- [Wallabag URL](https://wb.julianprester.com/view/579)
- [Original URL](https://boredbat.com/american-workers-are-stuck-in-place-because-everyone-is-too-afraid-of-a-recession-to-quit/#google_vignette)