### PR TITLE
[SOCIALBOT]: American workers are stuck in place because everyone is too afraid of a recession to quit

### DIFF
--- a/src/links/american-workers-are-stuck-in-place-because-everyone-is-too-afraid-of-a-recession-to-quit.md
+++ b/src/links/american-workers-are-stuck-in-place-because-everyone-is-too-afraid-of-a-recession-to-quit.md
@@ -1,0 +1,10 @@
+---
+title: 'American workers are stuck in place because everyone is too afraid of a recession to quit'
+url: https://boredbat.com/american-workers-are-stuck-in-place-because-everyone-is-too-afraid-of-a-recession-to-quit/#google_vignette
+date: 2024-08-18
+thumbnail: https://boredbat.com/wp-content/uploads/2024/08/image-12.jpeg
+tags:
+  - links
+---
+
+Job market stagnation creates "stuck" workers, unwilling to quit despite dissatisfaction. With recession fears looming, employees prioritize security over career moves. This shift signals a deeper economic uncertainty that may persist even as monetary policy loosens. A concerning trend for labor market dynamism.


### PR DESCRIPTION
Job market stagnation creates "stuck" workers, unwilling to quit despite dissatisfaction. With recession fears looming, employees prioritize security over career moves. This shift signals a deeper economic uncertainty that may persist even as monetary policy loosens. A concerning trend for labor market dynamism.

- [Wallabag URL](https://wb.julianprester.com/view/579)
- [Original URL](https://boredbat.com/american-workers-are-stuck-in-place-because-everyone-is-too-afraid-of-a-recession-to-quit/#google_vignette)