### PR TITLE
[SOCIALBOT]: "Can AI Scaling Continue Through 2030?", Epoch AI (yes)

### DIFF
--- a/src/links/can-ai-scaling-continue-through-2030-epoch-ai-yes.md
+++ b/src/links/can-ai-scaling-continue-through-2030-epoch-ai-yes.md
@@ -1,0 +1,10 @@
+---
+title: '"Can AI Scaling Continue Through 2030?", Epoch AI (yes)'
+url: https://www.lesswrong.com/posts/SoWperLCkunB9ijGq/can-ai-scaling-continue-through-2030-epoch-ai-yes
+date: 2024-09-19
+thumbnail: https://res.cloudinary.com/lesswrong-2-0/image/upload/f_auto,q_auto/v1/mirroredImages/SoWperLCkunB9ijGq/e3oghpji5qrrmobnfv0w
+tags:
+  - links
+---
+
+Epoch estimates that AI training runs could reach GPT-4-like scale increases by 2030, primarily constrained by power and chip production. While technically feasible, realizing this potential hinges on massive investments and infrastructure expansion. Is this AI's moonshot moment, or another hype cycle?

--- a/src/links/can-ai-scaling-continue-through-2030-epoch-ai-yes.md
+++ b/src/links/can-ai-scaling-continue-through-2030-epoch-ai-yes.md
@@ -7,4 +7,4 @@ tags:
   - links
 ---
 
-Epoch estimates that AI training runs could reach GPT-4-like scale increases by 2030, primarily constrained by power and chip production. While technically feasible, realizing this potential hinges on massive investments and infrastructure expansion. Is this AI's moonshot moment, or another hype cycle?
+Epoch estimates that AI training runs could reach GPT-4-like scale increases by 2030, primarily constrained by power and chip production. This requires massive investments and infrastructure expansion.


### PR DESCRIPTION
Epoch estimates that AI training runs could reach GPT-4-like scale increases by 2030, primarily constrained by power and chip production. While technically feasible, realizing this potential hinges on massive investments and infrastructure expansion. Is this AI's moonshot moment, or another hype cycle?

- [Wallabag URL](https://wb.julianprester.com/view/593)
- [Original URL](https://www.lesswrong.com/posts/SoWperLCkunB9ijGq/can-ai-scaling-continue-through-2030-epoch-ai-yes)