### PR TITLE
[SOCIALBOT]: Google’s AI ‘Reimagine’ tool helped us add wrecks, disasters, and corpses to our photos

### DIFF
--- a/src/links/googles-ai-reimagine-tool-helped-us-add-wrecks-disasters-and-corpses-to-our-photos.md
+++ b/src/links/googles-ai-reimagine-tool-helped-us-add-wrecks-disasters-and-corpses-to-our-photos.md
@@ -1,0 +1,10 @@
+---
+title: 'Google’s AI ‘Reimagine’ tool helped us add wrecks, disasters, and corpses to our photos'
+url: https://www.theverge.com/2024/8/21/24224084/google-pixel-9-reimagine-ai-photos
+date: 2024-09-19
+thumbnail: https://cdn.vox-cdn.com/thumbor/3Cad8eKxPpG6teMc0RvLIhoedfk=/0x0:2250x1500/1200x628/filters:focal(503x745:504x746)/cdn.vox-cdn.com/uploads/chorus_asset/file/25582867/ai_label__2_.png
+tags:
+  - links
+---
+
+Google's new Pixel photo editing AI, Reimagine, can generate disturbingly realistic alterations to images, including fake crime scenes. This raises serious concerns about the ease of creating and spreading misinformation. We're rapidly losing the ability to distinguish reality from AI-generated fakes.


### PR DESCRIPTION
Google's new Pixel photo editing AI, Reimagine, can generate disturbingly realistic alterations to images, including fake crime scenes. This raises serious concerns about the ease of creating and spreading misinformation. We're rapidly losing the ability to distinguish reality from AI-generated fakes.

- [Wallabag URL](https://wb.julianprester.com/view/592)
- [Original URL](https://www.theverge.com/2024/8/21/24224084/google-pixel-9-reimagine-ai-photos)