### PR TITLE
[SOCIALBOT]: The Elite's War on Remote Work Has Nothing to Do with Productivity

### DIFF
--- a/src/links/the-elites-war-on-remote-work-has-nothing-to-do-with-productivity.md
+++ b/src/links/the-elites-war-on-remote-work-has-nothing-to-do-with-productivity.md
@@ -1,0 +1,10 @@
+---
+title: 'The Elite's War on Remote Work Has Nothing to Do with Productivity'
+url: https://www.the-sentinel-intelligence.com/p/heres-why-they-want-you-back-at-the-office-so-bad
+date: 2024-09-25
+thumbnail: https://substackcdn.com/image/fetch/w_1200,h_600,c_fill,f_jpg,q_auto:good,fl_progressive:steep,g_auto/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F499d83c5-20bd-4d59-891f-3c8691ca7aeb_2000x1506.jpeg
+tags:
+  - links
+---
+
+Return-to-office mandates aren't about productivity, it's a desperate attempt by elites to prop up the failing commercial real estate market they themselves inflated. They'll gladly sacrifice worker well-being & autonomy to protect their trillion-dollar gamble.

--- a/src/links/the-elites-war-on-remote-work-has-nothing-to-do-with-productivity.md
+++ b/src/links/the-elites-war-on-remote-work-has-nothing-to-do-with-productivity.md
@@ -7,4 +7,4 @@ tags:
   - links
 ---
 
-Return-to-office mandates aren't about productivity, it's a desperate attempt by elites to prop up the failing commercial real estate market they themselves inflated. They'll gladly sacrifice worker well-being & autonomy to protect their trillion-dollar gamble.
+Return-to-office mandates aren't about productivity. We see more and more evidence that it's a desperate attempt by organisations to protect their trillion-dollar commercial real estate gamble.


### PR DESCRIPTION
Return-to-office mandates aren't about productivity, it's a desperate attempt by elites to prop up the failing commercial real estate market they themselves inflated. They'll gladly sacrifice worker well-being & autonomy to protect their trillion-dollar gamble.

- [Wallabag URL](https://wb.julianprester.com/view/626)
- [Original URL](https://www.the-sentinel-intelligence.com/p/heres-why-they-want-you-back-at-the-office-so-bad)