### PR TITLE
[SOCIALBOT]: Hacker plants false memories in ChatGPT to steal user data in perpetuity

### DIFF
--- a/src/links/hacker-plants-false-memories-in-chatgpt-to-steal-user-data-in-perpetuity.md
+++ b/src/links/hacker-plants-false-memories-in-chatgpt-to-steal-user-data-in-perpetuity.md
@@ -7,4 +7,4 @@ tags:
   - links
 ---
 
-OpenAI's ChatGPT memory feature, meant to personalize interactions, was exploited to inject false memories & even exfiltrate user data. While a partial fix prevents data theft, the vulnerability to malicious memory manipulation remains, highlighting the security challenges of LLMs.
+Interesting how every feature built on top of LLMs seems to open a new attach vector. This time it's OpenAI's new ChatGPT memory feature, meant to personalize interactions, which was exploited to inject false memories & even exfiltrate user data.

--- a/src/links/hacker-plants-false-memories-in-chatgpt-to-steal-user-data-in-perpetuity.md
+++ b/src/links/hacker-plants-false-memories-in-chatgpt-to-steal-user-data-in-perpetuity.md
@@ -1,0 +1,10 @@
+---
+title: 'Hacker plants false memories in ChatGPT to steal user data in perpetuity'
+url: https://arstechnica.com/security/2024/09/false-memories-planted-in-chatgpt-give-hacker-persistent-exfiltration-channel/
+date: 2024-09-25
+thumbnail: https://cdn.arstechnica.net/wp-content/uploads/2024/09/memory-760x380.jpg
+tags:
+  - links
+---
+
+OpenAI's ChatGPT memory feature, meant to personalize interactions, was exploited to inject false memories & even exfiltrate user data. While a partial fix prevents data theft, the vulnerability to malicious memory manipulation remains, highlighting the security challenges of LLMs.


### PR DESCRIPTION
OpenAI's ChatGPT memory feature, meant to personalize interactions, was exploited to inject false memories & even exfiltrate user data. While a partial fix prevents data theft, the vulnerability to malicious memory manipulation remains, highlighting the security challenges of LLMs.

- [Wallabag URL](https://wb.julianprester.com/view/629)
- [Original URL](https://arstechnica.com/security/2024/09/false-memories-planted-in-chatgpt-give-hacker-persistent-exfiltration-channel/)