### PR TITLE
[SOCIALBOT]: Forget ChatGPT: why researchers now run small AIs on their laptops

### DIFF
--- a/src/links/forget-chatgpt-why-researchers-now-run-small-ais-on-their-laptops.md
+++ b/src/links/forget-chatgpt-why-researchers-now-run-small-ais-on-their-laptops.md
@@ -1,0 +1,10 @@
+---
+title: 'Forget ChatGPT: why researchers now run small AIs on their laptops'
+url: https://www.nature.com/articles/d41586-024-02998-y?error=cookies_not_supported&code=bc17dd64-a308-48c6-8c0a-deb3edf48c0d
+date: 2024-09-26
+thumbnail: https://media.nature.com/lw1200/magazine-assets/d41586-024-02998-y/d41586-024-02998-y_27684494.jpg
+tags:
+  - links
+---
+
+Open-weight LLMs running locally are gaining traction! Researchers are using them to bypass costs, protect privacy & ensure reproducibility.  While cloud-based models still have advantages, the rapid progress of local LLMs suggests they might become sufficient for most use cases soon.


### PR DESCRIPTION
Open-weight LLMs running locally are gaining traction! Researchers are using them to bypass costs, protect privacy & ensure reproducibility.  While cloud-based models still have advantages, the rapid progress of local LLMs suggests they might become sufficient for most use cases soon.

- [Wallabag URL](https://wb.julianprester.com/view/621)
- [Original URL](https://www.nature.com/articles/d41586-024-02998-y?error=cookies_not_supported&code=bc17dd64-a308-48c6-8c0a-deb3edf48c0d)