### PR TITLE
[SOCIALBOT]: Working in the office 5 days a week to build company culture is a myth, PwC report says

### DIFF
--- a/src/links/working-in-the-office-5-days-a-week-to-build-company-culture-is-a-myth-pwc-report-says.md
+++ b/src/links/working-in-the-office-5-days-a-week-to-build-company-culture-is-a-myth-pwc-report-says.md
@@ -1,0 +1,10 @@
+---
+title: 'Working in the office 5 days a week to build company culture is a myth, PwC report says'
+url: https://www.msn.com/en-us/money/other/working-in-the-office-5-days-a-week-to-build-company-culture-is-a-myth-pwc-report-says/ar-AA1qU17L
+date: 2024-09-26
+thumbnail: https://img-s-msn-com.akamaized.net/tenant/amp/entityid/AA1qU17u.img?w=2048&h=1365&m=4&q=88
+tags:
+  - links
+---
+
+PwC research suggests that forcing employees back to the office full-time can actually *harm* company culture and engagement. Maybe Amazon and other companies pushing RTO mandates should take note? Flexibility fosters a stronger sense of belonging and autonomy, not surveillance.


### PR DESCRIPTION
PwC research suggests that forcing employees back to the office full-time can actually *harm* company culture and engagement. Maybe Amazon and other companies pushing RTO mandates should take note? Flexibility fosters a stronger sense of belonging and autonomy, not surveillance.

- [Wallabag URL](https://wb.julianprester.com/view/620)
- [Original URL](https://www.msn.com/en-us/money/other/working-in-the-office-5-days-a-week-to-build-company-culture-is-a-myth-pwc-report-says/ar-AA1qU17L)