### PR TITLE
[SOCIALBOT]: LLMs struggle to explain themselves

### DIFF
--- a/src/links/llms-struggle-to-explain-themselves.md
+++ b/src/links/llms-struggle-to-explain-themselves.md
@@ -1,0 +1,10 @@
+---
+title: 'LLMs struggle to explain themselves'
+url: https://www.jonathanychan.com/blog/llms-struggle-to-explain-themselves/
+date: 2024-09-27
+thumbnail: None
+tags:
+  - links
+---
+
+LLMs struggle to explain even simple number patterns they can sometimes recognize. A new interactive demo shows how LLMs fail to provide coherent reasoning despite access to tools and multiple attempts. Are impressive benchmarks masking fundamental reasoning limitations?


### PR DESCRIPTION
LLMs struggle to explain even simple number patterns they can sometimes recognize. A new interactive demo shows how LLMs fail to provide coherent reasoning despite access to tools and multiple attempts. Are impressive benchmarks masking fundamental reasoning limitations?

- [Wallabag URL](https://wb.julianprester.com/view/604)
- [Original URL](https://www.jonathanychan.com/blog/llms-struggle-to-explain-themselves/)