### PR TITLE
[SOCIALBOT]: 100M Token Context Windows

### DIFF
--- a/src/links/100m-token-context-windows.md
+++ b/src/links/100m-token-context-windows.md
@@ -7,4 +7,4 @@ tags:
   - links
 ---
 
-Magic claims to have built a 100M token context model that's 1000x cheaper than Llama at the same context length.  However, their evaluation method (HashHop) is questionable and the provided examples of code generation are underwhelming for a model of this supposed scale.
+Magic claims to have built a 100M token context model that's 1000x cheaper than Llama at the same context length.  Although there are still some question marks regarding evaluation, the increasing context trend is clear.

--- a/src/links/100m-token-context-windows.md
+++ b/src/links/100m-token-context-windows.md
@@ -1,0 +1,10 @@
+---
+title: '100M Token Context Windows'
+url: https://magic.dev/blog/100m-token-context-windows
+date: 2024-09-28
+thumbnail: https://magic.dev/blog/100m-token-context-windows/hero.png
+tags:
+  - links
+---
+
+Magic claims to have built a 100M token context model that's 1000x cheaper than Llama at the same context length.  However, their evaluation method (HashHop) is questionable and the provided examples of code generation are underwhelming for a model of this supposed scale.


### PR DESCRIPTION
Magic claims to have built a 100M token context model that's 1000x cheaper than Llama at the same context length.  However, their evaluation method (HashHop) is questionable and the provided examples of code generation are underwhelming for a model of this supposed scale.

- [Wallabag URL](https://wb.julianprester.com/view/599)
- [Original URL](https://magic.dev/blog/100m-token-context-windows)