### PR TITLE
[SOCIALBOT]: Two kinds of LLM responses: Informational vs Instructional

### DIFF
--- a/src/links/two-kinds-of-llm-responses-informational-vs-instructional.md
+++ b/src/links/two-kinds-of-llm-responses-informational-vs-instructional.md
@@ -1,0 +1,10 @@
+---
+title: 'Two kinds of LLM responses: Informational vs Instructional'
+url: https://shabie.github.io/2024/09/23/two-kinds-llm-responses.html
+date: 2024-09-28
+thumbnail: None
+tags:
+  - links
+---
+
+Current LLM evaluation benchmarks focus on short, factual answers, neglecting the instructional aspect where LLMs provide step-by-step guides. This is a crucial gap, especially for enterprise RAG systems where accuracy of instructions is paramount. Are we evaluating the right things?


### PR DESCRIPTION
Current LLM evaluation benchmarks focus on short, factual answers, neglecting the instructional aspect where LLMs provide step-by-step guides. This is a crucial gap, especially for enterprise RAG systems where accuracy of instructions is paramount. Are we evaluating the right things?

- [Wallabag URL](https://wb.julianprester.com/view/633)
- [Original URL](https://shabie.github.io/2024/09/23/two-kinds-llm-responses.html)