### PR TITLE
[SOCIALBOT]: openai-chief-technology-officer-resigns-7a8b4639

### DIFF
--- a/src/links/openai-chief-technology-officer-resigns-7a8b4639.md
+++ b/src/links/openai-chief-technology-officer-resigns-7a8b4639.md
@@ -1,0 +1,10 @@
+---
+title: 'openai-chief-technology-officer-resigns-7a8b4639'
+url: https://www.wsj.com/tech/ai/openai-chief-technology-officer-resigns-7a8b4639
+date: 2024-09-28
+thumbnail: None
+tags:
+  - links
+---
+
+It's frustrating when a read-it-later service like wallabag fails to retrieve article content. Is this a sign of increasing incompatibility with the ever-changing web, or just a temporary glitch?


### PR DESCRIPTION
It's frustrating when a read-it-later service like wallabag fails to retrieve article content. Is this a sign of increasing incompatibility with the ever-changing web, or just a temporary glitch?

- [Wallabag URL](https://wb.julianprester.com/view/632)
- [Original URL](https://www.wsj.com/tech/ai/openai-chief-technology-officer-resigns-7a8b4639)