### PR TITLE
[SOCIALBOT]: OpenAI Takes Its Mask Off

### DIFF
--- a/src/links/openai-takes-its-mask-off.md
+++ b/src/links/openai-takes-its-mask-off.md
@@ -1,0 +1,10 @@
+---
+title: 'OpenAI Takes Its Mask Off'
+url: https://www.theatlantic.com/technology/archive/2024/09/sam-altman-openai-for-profit/680031/
+date: 2024-09-28
+thumbnail: https://cdn.theatlantic.com/thumbor/e8SNAid8aFjlPywjYRDjNQxwEUg=/0x450:5590x3361/1200x625/media/img/mt/2024/09/GettyImages_1778705445/original.jpg
+tags:
+  - links
+---
+
+OpenAI is finally and officially becoming what it always was: Sam Altman's company. This is just the logical conclusion of Altman's ruthless consolidation of power after he became CEO.


### PR DESCRIPTION
OpenAI is finally and officially becoming what it always was: Sam Altman's company. This is just the logical conclusion of Altman's ruthless consolidation of power after he became CEO.

- [Wallabag URL](https://wb.julianprester.com/view/631)
- [Original URL](https://www.theatlantic.com/technology/archive/2024/09/sam-altman-openai-for-profit/680031/)