### PR TITLE
[SOCIALBOT]: Behind OpenAI’s Audacious Plan to Make A.I. Flow Like Electricity

### DIFF
--- a/src/links/behind-openais-audacious-plan-to-make-ai-flow-like-electricity.md
+++ b/src/links/behind-openais-audacious-plan-to-make-ai-flow-like-electricity.md
@@ -1,0 +1,10 @@
+---
+title: 'Behind OpenAI’s Audacious Plan to Make A.I. Flow Like Electricity'
+url: https://www.nytimes.com/2024/09/25/business/openai-plan-electricity.html
+date: 2024-09-28
+thumbnail: https://static01.nyt.com/images/2024/09/19/multimedia/00openai-chips-jhzb/00openai-chips-jhzb-facebookJumbo.jpg
+tags:
+  - links
+---
+
+OpenAI's CEO is on a global quest for trillions to build AI infrastructure, raising eyebrows in Washington and sparking concerns about a potential AI arms race. Is this a necessary step for progress or a dangerous power grab?


### PR DESCRIPTION
OpenAI's CEO is on a global quest for trillions to build AI infrastructure, raising eyebrows in Washington and sparking concerns about a potential AI arms race. Is this a necessary step for progress or a dangerous power grab?

- [Wallabag URL](https://wb.julianprester.com/view/630)
- [Original URL](https://www.nytimes.com/2024/09/25/business/openai-plan-electricity.html)