### PR TITLE
[SOCIALBOT]: How to Opt Out of A.I. Online

### DIFF
--- a/src/links/how-to-opt-out-of-ai-online.md
+++ b/src/links/how-to-opt-out-of-ai-online.md
@@ -1,0 +1,10 @@
+---
+title: 'How to Opt Out of A.I. Online'
+url: https://www.newyorker.com/culture/infinite-scroll/how-to-opt-out-of-ai-online
+date: 2024-10-04T21:16:17.632Z
+thumbnail: https://media.newyorker.com/photos/66fc4d26e72e17242335986b/16:9/w_1280,c_limit/NewYorker_AIescape_final%20copy.jpg
+tags:
+  - links
+---
+
+The delusion of opting out of AI: No magic words can stop your data from being used, and even if you could, the flood of AI-generated 'slop' content is unavoidable. Tech giants are prioritizing engagement over user experience, pushing AI whether we want it or not.


### PR DESCRIPTION
The delusion of opting out of AI: No magic words can stop your data from being used, and even if you could, the flood of AI-generated 'slop' content is unavoidable. Tech giants are prioritizing engagement over user experience, pushing AI whether we want it or not.

- [Wallabag URL](https://wb.julianprester.com/view/638)
- [Original URL](https://www.newyorker.com/culture/infinite-scroll/how-to-opt-out-of-ai-online)