### PR TITLE
[SOCIALBOT]: Sam Altman Goes Full Emperor

### DIFF
--- a/src/links/sam-altman-goes-full-emperor.md
+++ b/src/links/sam-altman-goes-full-emperor.md
@@ -1,0 +1,8 @@
+---
+title: Sam Altman Goes Full Emperor
+url: 'https://nonzero.substack.com/p/sam-altman-goes-full-emperor'
+date: '2024-10-08T21:17:43.674Z'
+thumbnail: >-
+  https://substackcdn.com/image/fetch/w_1200,h_600,c_fill,f_jpg,q_auto:good,fl_progressive:steep,g_auto/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F49d6a5a0-b660-4d16-a813-024e9eb2235a_1472x1128.png
+---
+Sam Altman's congressional testimony on AI safety now looks like a masterclass in deception. His recent moves reveal a dangerous accelerationist agenda, prioritizing power and profit over cautious development. Are we comfortable with him steering the future of AI?


### PR DESCRIPTION
Sam Altman's congressional testimony on AI safety now looks like a masterclass in deception. His recent moves reveal a dangerous accelerationist agenda, prioritizing power and profit over cautious development. Are we comfortable with him steering the future of AI?

- [Wallabag URL](https://wb.julianprester.com/view/639)
- [Original URL](https://nonzero.substack.com/p/sam-altman-goes-full-emperor)