### PR TITLE
[SOCIALBOT]: The AGI Entente Delusion

### DIFF
--- a/src/links/the-agi-entente-delusion.md
+++ b/src/links/the-agi-entente-delusion.md
@@ -1,0 +1,8 @@
+---
+title: The AGI Entente Delusion
+url: 'https://www.lesswrong.com/posts/oJQnRDbgSS8i6DwNu/the-agi-entente-delusion'
+date: '2024-10-14T21:16:15.438Z'
+thumbnail: >-
+  https://res.cloudinary.com/lesswrong-2-0/image/upload/f_auto,q_auto/v1/mirroredImages/oJQnRDbgSS8i6DwNu/vphtkhjlmousen2syucd
+---
+The "race to AGI" strategy is fundamentally flawed. It's a suicide race where losing control to unaligned AI is the most likely outcome. Let's focus on safe and beneficial tool AI development with strong safety standards, not on a reckless pursuit of AGI hegemony.


### PR DESCRIPTION
The "race to AGI" strategy is fundamentally flawed. It's a suicide race where losing control to unaligned AI is the most likely outcome. Let's focus on safe and beneficial tool AI development with strong safety standards, not on a reckless pursuit of AGI hegemony.

- [Wallabag URL](https://wb.julianprester.com/view/643)
- [Original URL](https://www.lesswrong.com/posts/oJQnRDbgSS8i6DwNu/the-agi-entente-delusion)