### PR TITLE
[SOCIALBOT]: The case for unlearning that removes information from LLM weights

### DIFF
--- a/src/links/the-case-for-unlearning-that-removes-information-from-llm-weights.md
+++ b/src/links/the-case-for-unlearning-that-removes-information-from-llm-weights.md
@@ -1,0 +1,9 @@
+---
+title: The case for unlearning that removes information from LLM weights
+url: >-
+  https://www.lesswrong.com/posts/9AbYkAy8s9LvB7dT5/the-case-for-unlearning-that-removes-information-from-llm
+date: '2024-10-15T21:16:58.524Z'
+thumbnail: >-
+  https://res.cloudinary.com/lesswrong-2-0/image/upload/f_auto,q_auto/v1/mirroredImages/9AbYkAy8s9LvB7dT5/co7boxlrbxrdtqngisx4
+---
+Current AI unlearning techniques can't reliably remove specific facts from models, which is concerning for safety.  We need better methods to remove sensitive information like bioweapon knowledge or hacking techniques from powerful AI, especially as they become more capable.


### PR DESCRIPTION
Current AI unlearning techniques can't reliably remove specific facts from models, which is concerning for safety.  We need better methods to remove sensitive information like bioweapon knowledge or hacking techniques from powerful AI, especially as they become more capable.

- [Wallabag URL](https://wb.julianprester.com/view/644)
- [Original URL](https://www.lesswrong.com/posts/9AbYkAy8s9LvB7dT5/the-case-for-unlearning-that-removes-information-from-llm)