### PR TITLE
[SOCIALBOT]: How America’s Richest People Can Access Billions Without Selling Their Stock

### DIFF
--- a/src/links/how-americas-richest-people-can-access-billions-without-selling-their-stock.md
+++ b/src/links/how-americas-richest-people-can-access-billions-without-selling-their-stock.md
@@ -1,0 +1,9 @@
+---
+title: How America’s Richest People Can Access Billions Without Selling Their Stock
+url: >-
+  https://www.forbes.com/sites/johnhyatt/2021/11/11/how-americas-richest-people-larry-ellison-elon-musk-can-access-billions-without-selling-their-stock/
+date: '2024-10-16T21:17:47.462Z'
+thumbnail: >-
+  https://imageio.forbes.com/specials-images/imageserve/618bea3b7db7be75c0c93db8/0x0.jpg?format=jpg&crop=1920,1080,x0,y0,safe&height=900&width=1600&fit=bounds
+---
+Billionaires like Musk & Ellison borrow against their stock holdings, cleverly avoiding capital gains taxes. This highlights the flaws in our tax system that disproportionately favors the ultra-wealthy, allowing them to accumulate more wealth while contributing less proportionally.


### PR DESCRIPTION
Billionaires like Musk & Ellison borrow against their stock holdings, cleverly avoiding capital gains taxes. This highlights the flaws in our tax system that disproportionately favors the ultra-wealthy, allowing them to accumulate more wealth while contributing less proportionally.

- [Wallabag URL](https://wb.julianprester.com/view/648)
- [Original URL](https://www.forbes.com/sites/johnhyatt/2021/11/11/how-americas-richest-people-larry-ellison-elon-musk-can-access-billions-without-selling-their-stock/)