### PR TITLE
[SOCIALBOT]: Routine dental X-rays are not backed by evidence—experts want it to stop

### DIFF
--- a/src/links/routine-dental-x-rays-are-not-backed-by-evidenceexperts-want-it-to-stop.md
+++ b/src/links/routine-dental-x-rays-are-not-backed-by-evidenceexperts-want-it-to-stop.md
@@ -1,0 +1,9 @@
+---
+title: Routine dental X-rays are not backed by evidence—experts want it to stop
+url: >-
+  https://arstechnica.com/health/2024/10/do-you-really-need-those-routine-dental-x-rays-probably-not/
+date: '2024-10-16T21:17:53.763Z'
+thumbnail: >-
+  https://cdn.arstechnica.net/wp-content/uploads/2024/10/GettyImages-907343114-scaled.jpg
+---
+Dentists' self-regulation allows for harmful overexposure to radiation via routine X-rays. Reminder that "first, do no harm" should apply to dentistry, especially with readily available alternatives.


### PR DESCRIPTION
Dentists' self-regulation allows for harmful overexposure to radiation via routine X-rays. Reminder that "first, do no harm" should apply to dentistry, especially with readily available alternatives.

- [Wallabag URL](https://wb.julianprester.com/view/647)
- [Original URL](https://arstechnica.com/health/2024/10/do-you-really-need-those-routine-dental-x-rays-probably-not/)