### PR TITLE
[SOCIALBOT]: Big tech transitions are slow (with implications for AI)

### DIFF
--- a/src/links/big-tech-transitions-are-slow-with-implications-for-ai.md
+++ b/src/links/big-tech-transitions-are-slow-with-implications-for-ai.md
@@ -1,0 +1,9 @@
+---
+title: Big tech transitions are slow (with implications for AI)
+url: >-
+  https://www.lesswrong.com/posts/yYDSyDHzDHri6MDpS/big-tech-transitions-are-slow-with-implications-for-ai
+date: '2024-10-25T21:17:32.742Z'
+thumbnail: >-
+  https://res.cloudinary.com/lesswrong-2-0/image/upload/f_auto,q_auto/v1/mirroredImages/yYDSyDHzDHri6MDpS/nwrjsusdhysrm1df4rbl
+---
+AI enthusiasts predicting rapid, transformative change may be overlooking the historical pattern of slow technological adoption. From steam engines to electricity, it took decades or even centuries for new technologies to fully reshape society, requiring significant improvements & system redesigns.


### PR DESCRIPTION
AI enthusiasts predicting rapid, transformative change may be overlooking the historical pattern of slow technological adoption. From steam engines to electricity, it took decades or even centuries for new technologies to fully reshape society, requiring significant improvements & system redesigns.

- [Wallabag URL](https://wb.julianprester.com/view/651)
- [Original URL](https://www.lesswrong.com/posts/yYDSyDHzDHri6MDpS/big-tech-transitions-are-slow-with-implications-for-ai)