### PR TITLE
[SOCIALBOT]: Brute-forcing the LLM guardrails

### DIFF
--- a/src/links/brute-forcing-the-llm-guardrails.md
+++ b/src/links/brute-forcing-the-llm-guardrails.md
@@ -1,0 +1,8 @@
+---
+title: Brute-forcing the LLM guardrails
+url: 'https://medium.com/@volkot/brute-forcing-the-llm-guardrails-e02fcd9bc9a4'
+date: '2024-11-03T21:16:31.188Z'
+thumbnail: 'https://miro.medium.com/v2/da:true/resize:fit:874/0*1M9ZZzJSO7Q6t2c4'
+syndicated: false
+---
+LLM guardrails are surprisingly easy to bypass. Brute-forcing prompts on Google Gemini shows a 60% success rate in getting medical interpretations from X-rays, despite safety measures.  Context similarity between prompt and desired response weakens guardrails significantly.


### PR DESCRIPTION
LLM guardrails are surprisingly easy to bypass. Brute-forcing prompts on Google Gemini shows a 60% success rate in getting medical interpretations from X-rays, despite safety measures.  Context similarity between prompt and desired response weakens guardrails significantly.

- [Wallabag URL](https://wb.julianprester.com/view/656)
- [Original URL](https://medium.com/@volkot/brute-forcing-the-llm-guardrails-e02fcd9bc9a4)