### PR TITLE
[SOCIALBOT]: Scalable watermarking for identifying large language model outputs - Nature

### DIFF
--- a/src/links/scalable-watermarking-for-identifying-large-language-model-outputs-nature.md
+++ b/src/links/scalable-watermarking-for-identifying-large-language-model-outputs-nature.md
@@ -7,4 +7,4 @@ thumbnail: >-
   https://media.springernature.com/m685/springer-static/image/art%3A10.1038%2Fs41586-024-08025-4/MediaObjects/41586_2024_8025_Fig1_HTML.png
 syndicated: false
 ---
-SynthID, a new watermarking method, claims to improve LLM-generated text detection.  Color me skeptical.  How robust will this *really* be against adversarial attacks or even just minor edits?  The watermarking arms race is on, and I doubt this is the silver bullet.
+SynthID, a new watermarking method, claims to improve LLM-generated text detection. How robust will this *really* be against adversarial attacks or even just minor edits?  The watermarking arms race is on, and I doubt this is the silver bullet.

--- a/src/links/scalable-watermarking-for-identifying-large-language-model-outputs-nature.md
+++ b/src/links/scalable-watermarking-for-identifying-large-language-model-outputs-nature.md
@@ -1,0 +1,10 @@
+---
+title: Scalable watermarking for identifying large language model outputs - Nature
+url: >-
+  https://www.nature.com/articles/s41586-024-08025-4?error=cookies_not_supported&code=5ec05732-fa45-4fce-a1c7-3ef0383c6f47
+date: '2024-11-06T21:17:41.423Z'
+thumbnail: >-
+  https://media.springernature.com/m685/springer-static/image/art%3A10.1038%2Fs41586-024-08025-4/MediaObjects/41586_2024_8025_Fig1_HTML.png
+syndicated: false
+---
+SynthID, a new watermarking method, claims to improve LLM-generated text detection.  Color me skeptical.  How robust will this *really* be against adversarial attacks or even just minor edits?  The watermarking arms race is on, and I doubt this is the silver bullet.


### PR DESCRIPTION
SynthID, a new watermarking method, claims to improve LLM-generated text detection.  Color me skeptical.  How robust will this *really* be against adversarial attacks or even just minor edits?  The watermarking arms race is on, and I doubt this is the silver bullet.

- [Wallabag URL](https://wb.julianprester.com/view/659)
- [Original URL](https://www.nature.com/articles/s41586-024-08025-4?error=cookies_not_supported&code=5ec05732-fa45-4fce-a1c7-3ef0383c6f47)