### PR TITLE
[SOCIALBOT]: Title:Evaluating the World Model Implicit in a Generative Model

### DIFF
--- a/src/links/titleevaluating-the-world-model-implicit-in-a-generative-model.md
+++ b/src/links/titleevaluating-the-world-model-implicit-in-a-generative-model.md
@@ -1,0 +1,8 @@
+---
+title: 'Title:Evaluating the World Model Implicit in a Generative Model'
+url: 'https://arxiv.org/abs/2406.03689'
+date: '2024-11-07T21:15:46.979Z'
+thumbnail: 'https://arxiv.org/static/browse/0.3.4/images/arxiv-logo-fb.png'
+syndicated: false
+---
+LLMs may seem to learn world models, but new research using deterministic finite automata reveals alarming incoherence.  Current metrics are misleading, masking a fragility that causes spectacular failures on slightly altered tasks.  True logical understanding remains elusive.


### PR DESCRIPTION
LLMs may seem to learn world models, but new research using deterministic finite automata reveals alarming incoherence.  Current metrics are misleading, masking a fragility that causes spectacular failures on slightly altered tasks.  True logical understanding remains elusive.

- [Wallabag URL](https://wb.julianprester.com/view/662)
- [Original URL](https://arxiv.org/abs/2406.03689)