### PR TITLE
[SOCIALBOT]: Title:Does your LLM truly unlearn? An embarrassingly simple approach to recover unlearned knowledge

### DIFF
--- a/src/links/titledoes-your-llm-truly-unlearn-an-embarrassingly-simple-approach-to-recover-unlearned-knowledge.md
+++ b/src/links/titledoes-your-llm-truly-unlearn-an-embarrassingly-simple-approach-to-recover-unlearned-knowledge.md
@@ -7,4 +7,4 @@ date: '2024-11-07T21:15:59.752Z'
 thumbnail: 'https://arxiv.org/static/browse/0.3.4/images/arxiv-logo-fb.png'
 syndicated: false
 ---
-So, "machine unlearning" for LLMs doesn't actually make them forget. Quantization brings the "unlearned" data right back.  Is anything ever truly deleted from these models?  This raises serious questions about data privacy and control.
+So, "machine unlearning" for LLMs doesn't actually make them forget. Quantization brings the "unlearned" data right back.  Is anything ever truly deleted from these models?

--- a/src/links/titledoes-your-llm-truly-unlearn-an-embarrassingly-simple-approach-to-recover-unlearned-knowledge.md
+++ b/src/links/titledoes-your-llm-truly-unlearn-an-embarrassingly-simple-approach-to-recover-unlearned-knowledge.md
@@ -1,0 +1,10 @@
+---
+title: >-
+  Title:Does your LLM truly unlearn? An embarrassingly simple approach to
+  recover unlearned knowledge
+url: 'https://arxiv.org/abs/2410.16454'
+date: '2024-11-07T21:15:59.752Z'
+thumbnail: 'https://arxiv.org/static/browse/0.3.4/images/arxiv-logo-fb.png'
+syndicated: false
+---
+So, "machine unlearning" for LLMs doesn't actually make them forget. Quantization brings the "unlearned" data right back.  Is anything ever truly deleted from these models?  This raises serious questions about data privacy and control.


### PR DESCRIPTION
So, "machine unlearning" for LLMs doesn't actually make them forget. Quantization brings the "unlearned" data right back.  Is anything ever truly deleted from these models?  This raises serious questions about data privacy and control.

- [Wallabag URL](https://wb.julianprester.com/view/657)
- [Original URL](https://arxiv.org/abs/2410.16454)