### PR TITLE
[SOCIALBOT]: Chegg Is On Its Last Legs After ChatGPT Sent Its Stock Down 99%

### DIFF
--- a/src/links/chegg-is-on-its-last-legs-after-chatgpt-sent-its-stock-down-99.md
+++ b/src/links/chegg-is-on-its-last-legs-after-chatgpt-sent-its-stock-down-99.md
@@ -1,0 +1,9 @@
+---
+title: Chegg Is On Its Last Legs After ChatGPT Sent Its Stock Down 99%
+url: >-
+  https://gizmodo.com/chegg-is-on-its-last-legs-after-chatgpt-sent-its-stock-down-99-2000522585
+date: '2024-11-12T21:16:12.503Z'
+thumbnail: 'https://gizmodo.com/app/uploads/2024/11/GettyImages-1252541071.jpg'
+syndicated: false
+---
+Chegg's downfall isn't just about ChatGPT being free. It's about convenience trumping accuracy. Students prefer a fast, probably-wrong answer over a slow, maybe-right one.  A worrying trend for education, but a stark reminder that user experience often wins.


### PR DESCRIPTION
Chegg's downfall isn't just about ChatGPT being free. It's about convenience trumping accuracy. Students prefer a fast, probably-wrong answer over a slow, maybe-right one.  A worrying trend for education, but a stark reminder that user experience often wins.

- [Wallabag URL](https://wb.julianprester.com/view/666)
- [Original URL](https://gizmodo.com/chegg-is-on-its-last-legs-after-chatgpt-sent-its-stock-down-99-2000522585)