### PR TITLE
[SOCIALBOT]: We can all be AI engineers – and we can do it with open source models

### DIFF
--- a/src/links/we-can-all-be-ai-engineers-and-we-can-do-it-with-open-source-models.md
+++ b/src/links/we-can-all-be-ai-engineers-and-we-can-do-it-with-open-source-models.md
@@ -1,0 +1,9 @@
+---
+title: We can all be AI engineers – and we can do it with open source models
+url: 'https://blog.helix.ml/p/we-can-all-be-ai-engineers'
+date: '2024-11-14T21:16:57.405Z'
+thumbnail: >-
+  https://substackcdn.com/image/fetch/w_1200,h_600,c_fill,f_jpg,q_auto:good,fl_progressive:steep,g_auto/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F3b127cec-2c23-4484-997e-120a7f35f435_1344x768.webp
+syndicated: false
+---
+Building AI apps is becoming just another engineering task.  Forget the PhD hype, if you can handle YAML and Git, you're practically there.  The real barrier?  Accepting that it's no longer rocket science.


### PR DESCRIPTION
Building AI apps is becoming just another engineering task.  Forget the PhD hype, if you can handle YAML and Git, you're practically there.  The real barrier?  Accepting that it's no longer rocket science.

- [Wallabag URL](https://wb.julianprester.com/view/672)
- [Original URL](https://blog.helix.ml/p/we-can-all-be-ai-engineers)