### PR TITLE
[SOCIALBOT]: AI Makes Tech Debt More Expensive

### DIFF
--- a/src/links/ai-makes-tech-debt-more-expensive.md
+++ b/src/links/ai-makes-tech-debt-more-expensive.md
@@ -6,4 +6,4 @@ thumbnail: >-
   https://cdn.prod.website-files.com/665a5f120c4c63df1944d627/673529427e9a3f24440903f2_673529288758869858b0a9d2_Screenshot%2520from%25202024-11-13%252014-32-42.png
 syndicated: false
 ---
-AI won't fix tech debt, it exacerbates it.  Clean codebases get an AI speed boost, while messy ones are left in the dust.  Modular architecture is no longer a nice-to-have, it's the key to unlocking AI's potential and staying competitive.
+AI won't fix tech debt, it exacerbates it.  Clean codebases will be much easier to working with AI.  Modular architecture is no longer a nice-to-have, it's the key to unlocking AI's potential and staying competitive.

--- a/src/links/ai-makes-tech-debt-more-expensive.md
+++ b/src/links/ai-makes-tech-debt-more-expensive.md
@@ -1,0 +1,9 @@
+---
+title: AI Makes Tech Debt More Expensive
+url: 'https://www.gauge.sh/blog/ai-makes-tech-debt-more-expensive'
+date: '2024-11-14T21:17:03.364Z'
+thumbnail: >-
+  https://cdn.prod.website-files.com/665a5f120c4c63df1944d627/673529427e9a3f24440903f2_673529288758869858b0a9d2_Screenshot%2520from%25202024-11-13%252014-32-42.png
+syndicated: false
+---
+AI won't fix tech debt, it exacerbates it.  Clean codebases get an AI speed boost, while messy ones are left in the dust.  Modular architecture is no longer a nice-to-have, it's the key to unlocking AI's potential and staying competitive.


### PR DESCRIPTION
AI won't fix tech debt, it exacerbates it.  Clean codebases get an AI speed boost, while messy ones are left in the dust.  Modular architecture is no longer a nice-to-have, it's the key to unlocking AI's potential and staying competitive.

- [Wallabag URL](https://wb.julianprester.com/view/671)
- [Original URL](https://www.gauge.sh/blog/ai-makes-tech-debt-more-expensive)