### PR TITLE
[SOCIALBOT]: ai-progress-stalls-openai-google-and-anthropic-hit-roadblocks

### DIFF
--- a/src/links/ai-progress-stalls-openai-google-and-anthropic-hit-roadblocks.md
+++ b/src/links/ai-progress-stalls-openai-google-and-anthropic-hit-roadblocks.md
@@ -1,0 +1,9 @@
+---
+title: ai-progress-stalls-openai-google-and-anthropic-hit-roadblocks
+url: >-
+  https://www.nasdaq.com/articles/ai-progress-stalls-openai-google-and-anthropic-hit-roadblocks
+date: '2024-11-14T21:17:15.982Z'
+thumbnail: null
+syndicated: false
+---
+Wallabag failing to fetch content?  More evidence that "read it later" services are increasingly fragile in a world of ever-changing web architecture.  Building personal archives is becoming a Sisyphean task.


### PR DESCRIPTION
Wallabag failing to fetch content?  More evidence that "read it later" services are increasingly fragile in a world of ever-changing web architecture.  Building personal archives is becoming a Sisyphean task.

- [Wallabag URL](https://wb.julianprester.com/view/669)
- [Original URL](https://www.nasdaq.com/articles/ai-progress-stalls-openai-google-and-anthropic-hit-roadblocks)