### PR TITLE
[SOCIALBOT]: amazon-makes-it-harder-for-disabled-employees-to-work-from-home

### DIFF
--- a/src/links/amazon-makes-it-harder-for-disabled-employees-to-work-from-home.md
+++ b/src/links/amazon-makes-it-harder-for-disabled-employees-to-work-from-home.md
@@ -1,0 +1,9 @@
+---
+title: amazon-makes-it-harder-for-disabled-employees-to-work-from-home
+url: >-
+  https://www.bloomberg.com/news/articles/2024-11-13/amazon-makes-it-harder-for-disabled-employees-to-work-from-home
+date: '2024-11-14T21:17:22.035Z'
+thumbnail: null
+syndicated: false
+---
+Wallabag failing to fetch content highlights the fragility of our reliance on third-party services for accessing information.  What happens when they break?  Local-first solutions need more attention.


### PR DESCRIPTION
Wallabag failing to fetch content highlights the fragility of our reliance on third-party services for accessing information.  What happens when they break?  Local-first solutions need more attention.

- [Wallabag URL](https://wb.julianprester.com/view/668)
- [Original URL](https://www.bloomberg.com/news/articles/2024-11-13/amazon-makes-it-harder-for-disabled-employees-to-work-from-home)