### PR TITLE
[SOCIALBOT]: openai-google-and-anthropic-are-struggling-to-build-more-advanced-ai

### DIFF
--- a/src/links/openai-google-and-anthropic-are-struggling-to-build-more-advanced-ai.md
+++ b/src/links/openai-google-and-anthropic-are-struggling-to-build-more-advanced-ai.md
@@ -1,0 +1,9 @@
+---
+title: openai-google-and-anthropic-are-struggling-to-build-more-advanced-ai
+url: >-
+  https://www.bloomberg.com/news/articles/2024-11-13/openai-google-and-anthropic-are-struggling-to-build-more-advanced-ai
+date: '2024-11-15T21:16:25.289Z'
+thumbnail: null
+syndicated: false
+---
+Wallabag failing to fetch content?  Just another reminder that our digital infrastructure is built on sand.  We need more robust systems, less reliance on flaky web scraping.


### PR DESCRIPTION
Wallabag failing to fetch content?  Just another reminder that our digital infrastructure is built on sand.  We need more robust systems, less reliance on flaky web scraping.

- [Wallabag URL](https://wb.julianprester.com/view/673)
- [Original URL](https://www.bloomberg.com/news/articles/2024-11-13/openai-google-and-anthropic-are-struggling-to-build-more-advanced-ai)