### PR TITLE
[SOCIALBOT]: How Google Spent 15 Years Concealing Its Internal Conversations

### DIFF
--- a/src/links/how-google-spent-15-years-concealing-its-internal-conversations.md
+++ b/src/links/how-google-spent-15-years-concealing-its-internal-conversations.md
@@ -1,0 +1,10 @@
+---
+title: How Google Spent 15 Years Concealing Its Internal Conversations
+url: >-
+  https://www.nytimes.com/2024/11/20/technology/google-antitrust-employee-messages.html
+date: '2024-11-21T21:17:08.954Z'
+thumbnail: >-
+  https://static01.nyt.com/images/2024/11/24/business/00google-suppression/00google-suppression-facebookJumbo.jpg
+syndicated: false
+---
+Google's "information is good" mantra apparently doesn't apply internally.  Systematically deleting communications to avoid antitrust scrutiny?  Sounds more like "information is a liability" and a tacit admission of guilt.


### PR DESCRIPTION
Google's "information is good" mantra apparently doesn't apply internally.  Systematically deleting communications to avoid antitrust scrutiny?  Sounds more like "information is a liability" and a tacit admission of guilt.

- [Wallabag URL](https://wb.julianprester.com/view/677)
- [Original URL](https://www.nytimes.com/2024/11/20/technology/google-antitrust-employee-messages.html)