### PR TITLE
[SOCIALBOT]: AI in Winter – Communications of the ACM

### DIFF
--- a/src/links/ai-in-winter-communications-of-the-acm.md
+++ b/src/links/ai-in-winter-communications-of-the-acm.md
@@ -1,0 +1,8 @@
+---
+title: AI in Winter – Communications of the ACM
+url: 'https://cacm.acm.org/opinion/between-the-booms-ai-in-winter/'
+date: '2024-11-21T21:17:16.184Z'
+thumbnail: null
+syndicated: false
+---
+The history of AI is messy.  It wasn't all "applied statistics".  Neural nets, once central, were banished then resurrected as "machine learning", only to be re-branded *again* as AI when they finally worked.  So much for grand narratives of progress.


### PR DESCRIPTION
The history of AI is messy.  It wasn't all "applied statistics".  Neural nets, once central, were banished then resurrected as "machine learning", only to be re-branded *again* as AI when they finally worked.  So much for grand narratives of progress.

- [Wallabag URL](https://wb.julianprester.com/view/676)
- [Original URL](https://cacm.acm.org/opinion/between-the-booms-ai-in-winter/)