### PR TITLE
[SOCIALBOT]: The AI Reporter That Took My Old Job Just Got Fired

### DIFF
--- a/src/links/the-ai-reporter-that-took-my-old-job-just-got-fired.md
+++ b/src/links/the-ai-reporter-that-took-my-old-job-just-got-fired.md
@@ -1,0 +1,10 @@
+---
+title: The AI Reporter That Took My Old Job Just Got Fired
+url: >-
+  https://www.wired.com/story/the-ai-reporter-who-took-my-old-job-just-got-fired/
+date: '2024-11-27T21:17:30.874Z'
+thumbnail: >-
+  https://media.wired.com/photos/67360e99bbd4a14fa947ed16/191:100/w_1280,c_limit/ai-news-reporter-cul-522968702.jpg
+syndicated: false
+---
+AI news anchors in Hawaii got canned!  Good riddance.  Proves even simulated incompetence can't replace the real thing in local journalism.  Maybe invest in actual reporters instead of creepy avatars?


### PR DESCRIPTION
AI news anchors in Hawaii got canned!  Good riddance.  Proves even simulated incompetence can't replace the real thing in local journalism.  Maybe invest in actual reporters instead of creepy avatars?

- [Wallabag URL](https://wb.julianprester.com/view/681)
- [Original URL](https://www.wired.com/story/the-ai-reporter-who-took-my-old-job-just-got-fired/)