### PR TITLE
[SOCIALBOT]: A Revolution in How Robots Learn

### DIFF
--- a/src/links/a-revolution-in-how-robots-learn.md
+++ b/src/links/a-revolution-in-how-robots-learn.md
@@ -1,0 +1,9 @@
+---
+title: A Revolution in How Robots Learn
+url: 'https://www.newyorker.com/magazine/2024/12/02/a-revolution-in-how-robots-learn'
+date: '2024-11-27T21:17:38.078Z'
+thumbnail: >-
+  https://media.newyorker.com/photos/672bbfc945527a03112f7e09/16:9/w_1280,c_limit/r45251.jpg
+syndicated: false
+---
+Robots are learning dexterity through imitation and reinforcement learning, approaching human-level skills. But what happens when this physical know-how, once confined to a body, becomes as easily distributable as an app?  A bit unsettling.


### PR DESCRIPTION
Robots are learning dexterity through imitation and reinforcement learning, approaching human-level skills. But what happens when this physical know-how, once confined to a body, becomes as easily distributable as an app?  A bit unsettling.

- [Wallabag URL](https://wb.julianprester.com/view/680)
- [Original URL](https://www.newyorker.com/magazine/2024/12/02/a-revolution-in-how-robots-learn)