### PR TITLE
[SOCIALBOT]: Title:The Curse of Recursion: Training on Generated Data Makes Models Forget

### DIFF
--- a/src/links/titlethe-curse-of-recursion-training-on-generated-data-makes-models-forget.md
+++ b/src/links/titlethe-curse-of-recursion-training-on-generated-data-makes-models-forget.md
@@ -1,0 +1,8 @@
+---
+title: 'Title:The Curse of Recursion: Training on Generated Data Makes Models Forget'
+url: 'https://arxiv.org/abs/2305.17493'
+date: '2024-12-07T21:16:09.395Z'
+thumbnail: 'https://arxiv.org/static/browse/0.3.4/images/arxiv-logo-fb.png'
+syndicated: false
+---
+LLMs are eating the internet.  Training future models on their own output will lead to "Model Collapse," a kind of inbreeding that destroys diversity and long-tail content.  Ironically, *real* human data is about to become even more precious.


### PR DESCRIPTION
LLMs are eating the internet.  Training future models on their own output will lead to "Model Collapse," a kind of inbreeding that destroys diversity and long-tail content.  Ironically, *real* human data is about to become even more precious.

- [Wallabag URL](https://wb.julianprester.com/view/685)
- [Original URL](https://arxiv.org/abs/2305.17493)