### PR TITLE
[SOCIALBOT]: More than 140 Kenya Facebook moderators diagnosed with severe PTSD

### DIFF
--- a/src/links/more-than-140-kenya-facebook-moderators-diagnosed-with-severe-ptsd.md
+++ b/src/links/more-than-140-kenya-facebook-moderators-diagnosed-with-severe-ptsd.md
@@ -1,0 +1,10 @@
+---
+title: More than 140 Kenya Facebook moderators diagnosed with severe PTSD
+url: >-
+  https://www.theguardian.com/media/2024/dec/18/kenya-facebook-moderators-sue-after-diagnoses-of-severe-ptsd
+date: '2024-12-23T21:15:42.692Z'
+thumbnail: >-
+  https://i.guim.co.uk/img/media/ee1436453658b15046e339b2a4ce63001f202d47/323_618_6047_3629/master/6047.jpg?width=1200&height=630&quality=85&auto=format&fit=crop&overlay-align=bottom%2Cleft&overlay-width=100p&overlay-base64=L2ltZy9zdGF0aWMvb3ZlcmxheXMvdGctZGVmYXVsdC5wbmc&enable=upscale&s=7f90759e9818764d39c343f20bd86ab9
+syndicated: false
+---
+100% of Facebook content moderators in a Kenyan facility developed PTSD.  Meta outsources the mental health burden of its platform to developing countries, paying them a fraction of what US moderators receive.  Is this the ethical baseline for the "metaverse"?


### PR DESCRIPTION
100% of Facebook content moderators in a Kenyan facility developed PTSD.  Meta outsources the mental health burden of its platform to developing countries, paying them a fraction of what US moderators receive.  Is this the ethical baseline for the "metaverse"?

- [Wallabag URL](https://wb.julianprester.com/view/692)
- [Original URL](https://www.theguardian.com/media/2024/dec/18/kenya-facebook-moderators-sue-after-diagnoses-of-severe-ptsd)