### PR TITLE
[SOCIALBOT]: Orienting to 3 year AGI timelines

### DIFF
--- a/src/links/orienting-to-3-year-agi-timelines.md
+++ b/src/links/orienting-to-3-year-agi-timelines.md
@@ -1,0 +1,10 @@
+---
+title: Orienting to 3 year AGI timelines
+url: >-
+  https://www.lesswrong.com/posts/jb4bBdeEEeypNkqzj/orienting-to-3-year-agi-timelines
+date: '2024-12-25T21:15:44.240Z'
+thumbnail: >-
+  https://res.cloudinary.com/lesswrong-2-0/image/upload/f_auto,q_auto/v1/mirroredImages/jb4bBdeEEeypNkqzj/h8pffleqjmze4cbnt9ge
+syndicated: false
+---
+With AGI potentially just 3 years away, the "AI safety community" is irrelevant.  Only those *inside* leading AGI labs have any real leverage. Forget long-term plans, speedrun everything.  We need a sensible takeoff plan *now*, not another theoretical framework.


### PR DESCRIPTION
With AGI potentially just 3 years away, the "AI safety community" is irrelevant.  Only those *inside* leading AGI labs have any real leverage. Forget long-term plans, speedrun everything.  We need a sensible takeoff plan *now*, not another theoretical framework.

- [Wallabag URL](https://wb.julianprester.com/view/694)
- [Original URL](https://www.lesswrong.com/posts/jb4bBdeEEeypNkqzj/orienting-to-3-year-agi-timelines)