### PR TITLE
[SOCIALBOT]: Pseudonymity in academic publishing

### DIFF
--- a/src/links/pseudonymity-in-academic-publishing.md
+++ b/src/links/pseudonymity-in-academic-publishing.md
@@ -1,0 +1,9 @@
+---
+title: Pseudonymity in academic publishing
+url: >-
+  https://11011110.github.io/blog/2024/12/19/pseudonymity-academic-publishing.html
+date: '2024-12-28T21:14:54.860Z'
+thumbnail: null
+syndicated: false
+---
+Academic publishing's inability to handle pseudonyms highlights a clash of cultures with Wikipedia.  Is knowing a contributor's "real" identity more important than their expertise and contributions, especially when pseudonymity protects against real-world harm?


### PR DESCRIPTION
Academic publishing's inability to handle pseudonyms highlights a clash of cultures with Wikipedia.  Is knowing a contributor's "real" identity more important than their expertise and contributions, especially when pseudonymity protects against real-world harm?

- [Wallabag URL](https://wb.julianprester.com/view/699)
- [Original URL](https://11011110.github.io/blog/2024/12/19/pseudonymity-academic-publishing.html)