### PR TITLE
[SOCIALBOT]: Meta’s Big Bet on Bots

### DIFF
--- a/src/links/metas-big-bet-on-bots.md
+++ b/src/links/metas-big-bet-on-bots.md
@@ -1,0 +1,10 @@
+---
+title: Meta’s Big Bet on Bots
+url: >-
+  https://nymag.com/intelligencer/article/meta-wants-more-ai-bots-on-facebook-and-instagram.html
+date: '2025-01-07T21:16:57.907Z'
+thumbnail: >-
+  https://pyxis.nymag.com/v1/imgs/65c/541/a2c532c324bf9eb7c599b8f9565068f013-topimage-moshed.1x.rsocial.w1200.jpg
+syndicated: false
+---
+Meta wants to populate its platforms with AI bots, claiming it's a novel idea. It's not. It's the next step in a long process of automation, rebranding its algorithm with a 'human-like' face. This is not social, it's just more advertising.


### PR DESCRIPTION
Meta wants to populate its platforms with AI bots, claiming it's a novel idea. It's not. It's the next step in a long process of automation, rebranding its algorithm with a 'human-like' face. This is not social, it's just more advertising.

- [Wallabag URL](https://wb.julianprester.com/view/701)
- [Original URL](https://nymag.com/intelligencer/article/meta-wants-more-ai-bots-on-facebook-and-instagram.html)