### PR TITLE
[SOCIALBOT]: o1 isn’t a chat model (and that’s the point)

### DIFF
--- a/src/links/o1-isnt-a-chat-model-and-thats-the-point.md
+++ b/src/links/o1-isnt-a-chat-model-and-thats-the-point.md
@@ -1,0 +1,9 @@
+---
+title: o1 isn’t a chat model (and that’s the point)
+url: 'https://www.latent.space/p/o1-skill-issue'
+date: '2025-01-14T21:16:48.213Z'
+thumbnail: >-
+  https://substackcdn.com/image/fetch/w_1200,h_600,c_fill,f_jpg,q_auto:good,fl_progressive:steep,g_auto/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F3e97fcc3-a572-4a87-b2c2-6fc016edd5dd_1276x598.png
+syndicated: false
+---
+The key to using o1 isn't chat, it's detailed "report generation" with maximal context upfront. Treat it like a new hire; spoon-feed it everything, and it will nail the output if you clearly specify "what", not "how". The future of AI is in high-latency, background intelligence.


### PR DESCRIPTION
The key to using o1 isn't chat, it's detailed "report generation" with maximal context upfront. Treat it like a new hire; spoon-feed it everything, and it will nail the output if you clearly specify "what", not "how". The future of AI is in high-latency, background intelligence.

- [Wallabag URL](https://wb.julianprester.com/view/719)
- [Original URL](https://www.latent.space/p/o1-skill-issue)