### PR TITLE
[SOCIALBOT]: Building AI Research Fleets

### DIFF
--- a/src/links/building-ai-research-fleets.md
+++ b/src/links/building-ai-research-fleets.md
@@ -1,0 +1,9 @@
+---
+title: Building AI Research Fleets
+url: 'https://www.lesswrong.com/posts/WJ7y8S9WdKRvrzJmR/building-ai-research-fleets'
+date: '2025-01-15T21:15:38.390Z'
+thumbnail: >-
+  https://res.cloudinary.com/lesswrong-2-0/image/upload/c_fill,ar_1.91,g_auto/SocialPreview/zcv3exahlcvtykbvrwiv
+syndicated: false
+---
+AI research isn't about individual "AI scientists" but about building "research fleets". We need new institutional structures and workflows for this, not just better models. Scaling labs get it, AI safety orgs need to catch up.


### PR DESCRIPTION
AI research isn't about individual "AI scientists" but about building "research fleets". We need new institutional structures and workflows for this, not just better models. Scaling labs get it, AI safety orgs need to catch up.

- [Wallabag URL](https://wb.julianprester.com/view/712)
- [Original URL](https://www.lesswrong.com/posts/WJ7y8S9WdKRvrzJmR/building-ai-research-fleets)