### PR TITLE
[SOCIALBOT]: Philosophy Eats AI

### DIFF
--- a/src/links/philosophy-eats-ai.md
+++ b/src/links/philosophy-eats-ai.md
@@ -1,0 +1,9 @@
+---
+title: Philosophy Eats AI
+url: 'https://sloanreview.mit.edu/article/philosophy-eats-ai/'
+date: '2025-01-20T21:15:23.779Z'
+thumbnail: >-
+  https://sloanreview.mit.edu/wp-content/uploads/2025/01/Kiron-final-1200x630.jpg
+syndicated: false
+---
+Philosophy is eating AI. We need to stop focusing on ethics and consider philosophy's influence on AI's goals (teleology), knowledge (epistemology), and reality (ontology) to create value. Otherwise, our AI investments will be philosophically bankrupt.


### PR DESCRIPTION
Philosophy is eating AI. We need to stop focusing on ethics and consider philosophy's influence on AI's goals (teleology), knowledge (epistemology), and reality (ontology) to create value. Otherwise, our AI investments will be philosophically bankrupt.

- [Wallabag URL](https://wb.julianprester.com/view/726)
- [Original URL](https://sloanreview.mit.edu/article/philosophy-eats-ai/)