### PR TITLE
[SOCIALBOT]: Scale AI and CAIS Unveil Results of Humanity’s Last Exam

### DIFF
--- a/src/links/scale-ai-and-cais-unveil-results-of-humanitys-last-exam.md
+++ b/src/links/scale-ai-and-cais-unveil-results-of-humanitys-last-exam.md
@@ -1,0 +1,8 @@
+---
+title: Scale AI and CAIS Unveil Results of Humanity’s Last Exam
+url: 'https://scale.com/blog/humanitys-last-exam-results'
+date: '2025-01-24T21:15:31.460Z'
+thumbnail: 'https://site-assets.plasmic.app/b09c387370f12402877736ae081282e6.png'
+syndicated: false
+---
+A new benchmark "Humanity's Last Exam" shows that frontier LLMs still can't answer expert-level questions, but only 10% correctly. How long until this also becomes another saturated benchmark? The goalposts are shifting faster than ever and it's not clear what we're measuring.


### PR DESCRIPTION
A new benchmark "Humanity's Last Exam" shows that frontier LLMs still can't answer expert-level questions, but only 10% correctly. How long until this also becomes another saturated benchmark? The goalposts are shifting faster than ever and it's not clear what we're measuring.

- [Wallabag URL](https://wb.julianprester.com/view/731)
- [Original URL](https://scale.com/blog/humanitys-last-exam-results)